### PR TITLE
fast forward `mas` branch in 3scale repos

### DIFF
--- a/.github/workflows/fast-forward-mas-branch.yaml
+++ b/.github/workflows/fast-forward-mas-branch.yaml
@@ -1,0 +1,36 @@
+---
+name: Fast Forward MAS Branch
+
+# Controls when the action will run. Workflow runs when manually triggered using the UI
+# or API.
+on:
+  workflow_dispatch:
+    # Inputs the workflow accepts.
+    inputs:
+      to_branch:
+        description: 'The MAS branch name'
+        default: 'managed-services'
+        type: string
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  fastForward3scaleMASBranch:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:  # This matrix allows multiple parallel jobs at various repos at the same time
+        repo:
+          - 3scale/apisonator
+          - 3scale/APIcast
+          - 3scale/apicast-operator
+          - 3scale/3scale-operator
+          - 3scale/3scale_toolbox
+    steps:
+      - name: Fast forward MAS branch for ${{ matrix.repo }}
+        uses: aurelien-baudet/workflow-dispatch@v2.1.1
+        with:
+          repo: ${{ matrix.repo }}
+          token: ${{ secrets.ACCESS_TOKEN_GITHUB }}
+          workflow: fast-forward-branch.yaml
+          inputs: '{ "to_branch": "${{ inputs.to_branch }}" }'
+          wait-for-completion: true
+          display-workflow-run-url: true

--- a/.github/workflows/fast-forward-mas-branch.yaml
+++ b/.github/workflows/fast-forward-mas-branch.yaml
@@ -18,19 +18,36 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:  # This matrix allows multiple parallel jobs at various repos at the same time
-        repo:
-          - 3scale/apisonator
-          - 3scale/APIcast
-          - 3scale/apicast-operator
-          - 3scale/3scale-operator
-          - 3scale/3scale_toolbox
+        include:
+          - repo: 3scale/apisonator
+            workflow: fast-forward-branch.yaml
+            ref: master
+          - repo: 3scale/APIcast
+            workflow: fast-forward-branch.yaml
+            ref: master
+          - repo: 3scale/apicast-operator
+            workflow: fast-forward-branch.yaml
+            ref: master
+          - repo: 3scale/3scale-operator
+            workflow: fast-forward-branch.yaml
+            ref: master
+          - repo: 3scale/3scale_toolbox
+            workflow: fast-forward-branch.yaml
+            ref: main
+          - repo: 3scale/zync
+            workflow: fast-forward-manual.yml
+            ref: master
+          - repo: 3scale/porta
+            workflow: fast-forward-manual.yml
+            ref: master
     steps:
       - name: Fast forward MAS branch for ${{ matrix.repo }}
         uses: aurelien-baudet/workflow-dispatch@v2.1.1
         with:
           repo: ${{ matrix.repo }}
+          ref: refs/heads/${{ matrix.ref }}
           token: ${{ secrets.ACCESS_TOKEN_GITHUB }}
-          workflow: fast-forward-branch.yaml
-          inputs: '{ "to_branch": "${{ inputs.to_branch }}" }'
+          workflow: ${{ matrix.workflow }}
+          inputs: '{ "ref": "${{ matrix.ref }}", "to_branch": "${{ inputs.to_branch }}" }'
           wait-for-completion: true
           display-workflow-run-url: true


### PR DESCRIPTION
TODO:
- [x] Missing Porta and Zync repos

This PR depends on:
- 3scale toolbox: https://github.com/3scale/3scale_toolbox/pull/375
- Apisonator: https://github.com/3scale/apisonator/pull/348
- APIcast: https://github.com/3scale/APIcast/pull/1402
- 3scale operator: https://github.com/3scale/3scale-operator/pull/831
- Apicast operator: https://github.com/3scale/apicast-operator/pull/196

Those PR need to be merged first