### PR TITLE
Update GitHub workflow

### DIFF
--- a/.github/workflows/createTagReleases.yml
+++ b/.github/workflows/createTagReleases.yml
@@ -47,27 +47,25 @@ jobs:
               REF="refs/heads/master"
             fi
 
-            gh workflow run tagRelease.yml \
+            # Capture the output from gh workflow run
+            OUTPUT=$(gh workflow run tagRelease.yml \
               --repo ${{ matrix.repo }} \
               --ref "$REF" \
               --field tag="${{ inputs.tag }}" \
-              --field git_ref="${{ inputs.git_ref }}"
+              --field git_ref="${{ inputs.git_ref }}" 2>&1)
 
-            # Wait for the workflow run to appear
-            sleep 5
+            echo "$OUTPUT"
 
-            # Get the latest run ID
-            RUN_ID=$(gh run list \
-              --repo ${{ matrix.repo }} \
-              --workflow tagRelease.yml \
-              --limit 1 \
-              --json databaseId \
-              --jq '.[0].databaseId')
+            # Extract the run ID from the URL in the output
+            # Expected format: https://github.com/3scale/porta/actions/runs/24573081426
+            RUN_ID=$(echo "$OUTPUT" | grep -oP 'actions/runs/\K[0-9]+' | head -1)
 
             if [ -z "$RUN_ID" ]; then
-              echo "Failed to find workflow run"
+              echo "Failed to extract workflow run ID from output"
               exit 1
             fi
+
+            echo "Extracted workflow run ID: $RUN_ID"
 
             echo "Workflow run URL: https://github.com/${{ matrix.repo }}/actions/runs/$RUN_ID"
             echo "Waiting for completion..."

--- a/.github/workflows/createTagReleases.yml
+++ b/.github/workflows/createTagReleases.yml
@@ -18,40 +18,59 @@ on:
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
-  # This workflow contains a single job called "greet"
   createRelease:
-      name: createRelease
+      name: Create Release for ${{ matrix.repo }}
       runs-on: ubuntu-latest
       strategy:
-        matrix: #This matrix allows multiple parallel jobs to create tags in the various repos at the same time
-          repo: [3scale/porta, 3scale/apisonator, 3scale/APIcast, 3scale/zync, 3scale/apicast-operator, 3scale/3scale-operator]
+        matrix:
+          include:
+            - repo: 3scale/porta
+            - repo: 3scale/apisonator
+            - repo: 3scale/APIcast
+            - repo: 3scale/zync
+            - repo: 3scale/apicast-operator
+            - repo: 3scale/3scale-operator
+            # - repo: 3scale/searchd
+            #   ref: refs/heads/main
+            # - repo: 3scale/3scale_toolbox
+            #   ref: refs/heads/main
       steps:
         - name: Create Release for ${{ matrix.repo }}
-          uses: aurelien-baudet/workflow-dispatch@v2.1.1
-          with:
-            ref: refs/heads/master # <-- this action is triggered in a repo with a 'main' branch, but targets a repo that uses 'master', this needs to be added as a workaround to stop workflow dispatch from triggering the action in a main branch that does not exist.
-            repo: ${{ matrix.repo }}
-            token: ${{ secrets.ACCESS_TOKEN_GITHUB }}
-            workflow: tagRelease.yml
-            inputs: '{ "tag": "${{ inputs.tag }}", "git_ref": "${{ inputs.git_ref }}"}'
-            wait-for-completion: true
-            display-workflow-run-url: true
-        - name: Create Release for 3scale/3scale_toolbox
-          uses: aurelien-baudet/workflow-dispatch@v2.1.1
-          with:
-            repo: 3scale/3scale_toolbox
-            token: ${{secrets.ACCESS_TOKEN_GITHUB}}
-            workflow: tagRelease.yml
-            inputs: '{ "tag": "${{ inputs.tag }}", "git_ref": "${{ inputs.git_ref }}"}'
-            wait-for-completion: true
-            display-workflow-run-url: true
-        - name: Create Release for 3scale/searchd
-          uses: aurelien-baudet/workflow-dispatch@v2.1.1
-          with:
-            repo: 3scale/searchd
-            token: ${{secrets.ACCESS_TOKEN_GITHUB}}
-            workflow: tagRelease.yml
-            inputs: '{ "tag": "${{ inputs.tag }}", "git_ref": "${{ inputs.git_ref }}"}'
-            wait-for-completion: true
-            display-workflow-run-url: true
-            
+          env:
+            GH_TOKEN: ${{ secrets.ACCESS_TOKEN_GITHUB }}
+          run: |
+            echo "Triggering workflow for ${{ matrix.repo }}..."
+
+            # Use refs/heads/master as default if ref is not set
+            REF="${{ matrix.ref }}"
+            if [ -z "$REF" ]; then
+              REF="refs/heads/master"
+            fi
+
+            gh workflow run tagRelease.yml \
+              --repo ${{ matrix.repo }} \
+              --ref "$REF" \
+              --field tag="${{ inputs.tag }}" \
+              --field git_ref="${{ inputs.git_ref }}"
+
+            # Wait for the workflow run to appear
+            sleep 5
+
+            # Get the latest run ID
+            RUN_ID=$(gh run list \
+              --repo ${{ matrix.repo }} \
+              --workflow tagRelease.yml \
+              --limit 1 \
+              --json databaseId \
+              --jq '.[0].databaseId')
+
+            if [ -z "$RUN_ID" ]; then
+              echo "Failed to find workflow run"
+              exit 1
+            fi
+
+            echo "Workflow run URL: https://github.com/${{ matrix.repo }}/actions/runs/$RUN_ID"
+            echo "Waiting for completion..."
+
+            # Wait for completion and exit with the same status
+            gh run watch $RUN_ID --repo ${{ matrix.repo }} --exit-status


### PR DESCRIPTION
This PR changes the GitHub action that triggers the `tagRelease` actions on multiple 3scale repositories.

It solves several issues:
- for some reason, the action on each repo was not receiving the status, so the job appeared as failed, even though the action succeeded in the target repo
- the job was executed for each of the repos from the list, but release for `3scale_toolbox` and `searchd` was run on **each iteration**, so as many times as other repos in the list, which was wrong.
- the action was relying on `aurelien-baudet/workflow-dispatch@v2.1.1` which is an old version of action, and it was throwing a warning about Node.js 20:
```
Warning: Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: softprops/action-gh-release@v1. Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026. Node.js 20 will be removed from the runner on September 16th, 2026. Please check if updated versions of these actions are available that support Node.js 24. To opt into Node.js 24 now, set the FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true environment variable on the runner or in your workflow file. Once Node.js 24 becomes the default, you can temporarily opt out by setting ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
```

Additionally, the `3scale_toolbox` step was not running, when the action was triggered from a branch, because the branch was not specified explicitly. This is not a big deal, because when merged to `main` this would have worked, but I think it's better to be explicit about the branch names.

So, in this PR these issues are fixed. The dependency on the third-party action is removed, because we can use the GitHub's default `gh` CLI, which is well-documented and always supported.

Also, the current code has less duplication.

A this time, tag releases in `searchd` and `3scale_toolbox` repos are disabled, the main reason being - we don't seem to have the `3scale-2.x-stable` branches on those repos to tag from. Maybe we should - I don't know :shrug:  But then it would be easy to uncomment those lines.